### PR TITLE
🔥 Remove removeProp calls

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -1,5 +1,4 @@
 import { includes, get, omit } from 'lodash'
-import { removeProps } from 'styled-system'
 
 const palette = {
   red: '#ff686b',
@@ -126,7 +125,7 @@ export const gradient = (color1, color2) =>
   )`
 
 export const filterProps = props =>
-  omit(removeProps(props), [
+  omit(props, [
     'theme',
     'xs',
     'sm',


### PR DESCRIPTION
removeProp was deprecated from styled-components. It's removal had no code changes, as omit was doing the job for it.